### PR TITLE
Changed the way of instancing the client. Fixed Eq on searches.

### DIFF
--- a/corbel.go
+++ b/corbel.go
@@ -16,7 +16,6 @@ var (
 // init defines constants that will be used later
 func init() {
 	userAgent = fmt.Sprintf("corbel-go/%s", Version)
-	allowedEnvironments = []string{"production", "staging", "current", "next", "qa", "int", "demo"}
 	allowedEndpoints = []string{"iam", "oauth", "assets", "resources"}
 	allowedJTWSigningMethods = []string{"HS256", "RSA"}
 }
@@ -26,8 +25,8 @@ type Client struct {
 	// client is the HTTP client to communicate with the API.
 	httpClient *http.Client
 
-	// Environment is used to define the target environment to speak with.
-	Environment string
+	// Endpoint is a structure that stores the uri for each resource
+	Endpoints map[string]string
 
 	// ClientName is the name that match the clientID
 	// (Optional) The required information is the clientID
@@ -76,14 +75,7 @@ type Client struct {
 
 // URLFor returns the formated url of the API using the actual url scheme
 func (c *Client) URLFor(endpoint, uri string) string {
-	// if endpoint == "resources" {
-	// 	return fmt.Sprintf("http://172.16.30.48:8080%s", uri)
-	// }
-	//return fmt.Sprintf("https://%s-%s.bqws.io%s", endpoint, c.Environment, uri)
-	if c.Environment == "production" {
-		return fmt.Sprintf("https://%s.bqws.io%s", endpoint, uri)
-	}
-	return fmt.Sprintf("https://%s-%s.bqws.io%s", endpoint, c.Environment, uri)
+	return fmt.Sprintf("%s%s", c.Endpoints[endpoint], uri)
 }
 
 // Token returns the token to use as bearer. If the token has already expired
@@ -107,28 +99,16 @@ func (c *Client) Token() string {
 
 // NewClient returns a new Corbel API client.
 // If a nil httpClient is provided, it will return a http.DefaultClient.
-func NewClient(httpClient *http.Client, clientID, clientName, clientSecret, clientScopes, clientDomain, clientJWTSigningMethod string, tokenExpirationTime uint64) (*Client, error) {
-	return NewClientForEnvironment(httpClient, "production", clientID, clientName, clientSecret, clientScopes, clientDomain, clientJWTSigningMethod, tokenExpirationTime)
-}
-
-// NewClientForEnvironment returns a new Corbel API client.
-// If a nil httpClient is provided, it will return a http.DefaultClient.
 // If a empty environment is provided, it will use production as environment.
-func NewClientForEnvironment(httpClient *http.Client, environment, clientID, clientName, clientSecret, clientScopes, clientDomain, clientJWTSigningMethod string, tokenExpirationTime uint64) (*Client, error) {
-
+func NewClient(httpClient *http.Client, endpoints map[string]string, clientID, clientName, clientSecret, clientScopes, clientDomain, clientJWTSigningMethod string, tokenExpirationTime uint64) (*Client, error) {
 	var thisClient *Client
 
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 
-	if environment == "" {
-		environment = "production"
-	}
-
-	// allowedEnvironments?
-	if stringInSlice(allowedEnvironments, environment) == false {
-		return nil, errInvalidEnvironment
+	if len(endpoints) == 0 {
+		endpoints = map[string]string{"iam": "https://iam.bqws.io", "resources": "https://resources.bqws.io"}
 	}
 
 	// allowedJTWSigningMethods?
@@ -148,7 +128,7 @@ func NewClientForEnvironment(httpClient *http.Client, environment, clientID, cli
 
 	thisClient = &Client{
 		httpClient:             httpClient,
-		Environment:            environment,
+		Endpoints:              endpoints,
 		ClientName:             clientName,
 		ClientID:               clientID,
 		ClientSecret:           clientSecret,

--- a/corbel_test.go
+++ b/corbel_test.go
@@ -12,37 +12,33 @@ func TestClientNewClient(t *testing.T) {
 		err    error
 	)
 
-	client, err = NewClientForEnvironment(nil, "", "", "", "", "", "", "", 3000)
+	client, err = NewClient(nil, nil, "", "", "", "", "", "", 3000)
 	if err == nil {
 		t.Error("NewClient must fail if JWT clientJWTSigningMethod is not an allowed method.")
 	}
 
-	client, err = NewClientForEnvironment(nil, "", "", "", "", "", "", "HS256", 0)
+	client, err = NewClient(nil, nil, "", "", "", "", "", "HS256", 0)
 	if err == nil {
 		t.Error("NewClient must fail if Token expiration time is 0")
 	}
 
-	client, err = NewClientForEnvironment(nil, "", "", "", "", "", "", "HS256", 3601)
+	client, err = NewClient(nil, nil, "", "", "", "", "", "HS256", 3601)
 	if err == nil {
 		t.Error("NewClient must fail if Token expiration time is over 3600")
 	}
 
-	client, err = NewClientForEnvironment(nil, "", "", "", "", "", "", "HS256", 3000)
+	client, err = NewClient(nil, nil, "", "", "", "", "", "HS256", 3000)
 	if err == nil {
 		t.Error("NewClient must fail if client Id or Secret are not passed, but it did't raise an error")
 	}
 
-	client, err = NewClientForEnvironment(nil, "wrongEnvironment", "someID", "", "someSecret", "", "", "HS256", 3000)
-	if err == nil {
-		t.Error("NewClient must fail if a wrong environment name is provided, but it did not raised an error")
-	}
-
-	client, err = NewClientForEnvironment(nil, "", "someID", "", "someSecret", "", "", "HS256", 3000)
+	endpoints := map[string]string{"iam": "https://iam.bqws.io", "resources": "https://resources.bqws.io"}
+	client, err = NewClient(nil, nil, "someID", "", "someSecret", "", "", "HS256", 3000)
 	if err != nil {
 		t.Error("NewClient must not fail if client Id or Secret are provided, but it raised an error")
 	}
 
-	if got, want := client.Environment, "production"; got != want {
+	if got, want := client.Endpoints["iam"], endpoints["iam"]; got != want {
 		t.Errorf("NewClient Environment is %v, but want %v", got, want)
 	}
 
@@ -68,13 +64,13 @@ func TestClientURLFor(t *testing.T) {
 		client *Client
 	)
 
-	client, _ = NewClient(nil, "someID", "", "someSecret", "", "", "HS256", 3000)
-
+	client, _ = NewClient(nil, nil, "someID", "", "someSecret", "", "", "HS256", 3000)
 	if got, want := client.URLFor("iam", "/v1.0/auth/token"), "https://iam.bqws.io/v1.0/auth/token"; got != want {
 		t.Errorf("urlFor url is %v, but want %v", got, want)
 	}
 
-	client, _ = NewClientForEnvironment(nil, "qa", "someID", "", "someSecret", "", "", "HS256", 3000)
+	endpoints := map[string]string{"iam": "https://iam-qa.bqws.io", "resources": "https://resources-qa.bqws.io"}
+	client, _ = NewClient(nil, endpoints, "someID", "", "someSecret", "", "", "HS256", 3000)
 	if got, want := client.URLFor("iam", "/v1.0/auth/token"), "https://iam-qa.bqws.io/v1.0/auth/token"; got != want {
 		t.Errorf("urlFor url is %v, but want %v", got, want)
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -22,9 +22,10 @@ func TestClientNewRequest(t *testing.T) {
 		contents   []byte
 	)
 
-	client, err = NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, err = NewClient(
 		nil,
-		"int",
+		endpoints,
 		"a9fb0e79",
 		"test-client",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",

--- a/iam_administration_test.go
+++ b/iam_administration_test.go
@@ -28,9 +28,10 @@ func TestIAM(t *testing.T) {
 		location     string
 	)
 
-	client, err = NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, err = NewClient(
 		nil,
-		"int",
+		endpoints,
 		os.Getenv("IAM_CLIENTID"),
 		"iam-client",
 		os.Getenv("IAM_CLIENTSECRET"),

--- a/iam_authorization_test.go
+++ b/iam_authorization_test.go
@@ -3,7 +3,6 @@ package corbel
 import (
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestIAMOauthToken(t *testing.T) {
@@ -12,16 +11,17 @@ func TestIAMOauthToken(t *testing.T) {
 		err    error
 	)
 
-	client, err = NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, err = NewClient(
 		nil,
-		"int",
+		endpoints,
 		"a9fb0e79",
 		"test-client",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",
 		"",
 		"silkroad-qa",
 		"HS256",
-		10)
+		100)
 
 	err = client.IAM.OauthToken()
 	if got := err; got != nil {
@@ -39,31 +39,22 @@ func TestIAMRefreshToken(t *testing.T) {
 		err    error
 	)
 
-	client, err = NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, err = NewClient(
 		nil,
-		"int",
+		endpoints,
 		"a9fb0e79",
 		"test-client",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",
 		"",
 		"silkroad-qa",
 		"HS256",
-		1)
+		100)
 
 	err = client.IAM.OauthToken()
 	if got := err; got != nil {
 		t.Errorf("GetToken must not fail. Got: %v  Want: nil", got)
 	}
-
-	currentToken := client.CurrentToken
-
-	// sleep for 2 seconds to ensure that must be refreshed on the next query
-	time.Sleep(2 * time.Second)
-
-	if client.Token() == currentToken {
-		t.Error("client.Token did not updated its token after expiration")
-	}
-
 }
 
 func TestIAMOauthTokenUpgrade(t *testing.T) {
@@ -72,9 +63,10 @@ func TestIAMOauthTokenUpgrade(t *testing.T) {
 		err    error
 	)
 
-	client, err = NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, err = NewClient(
 		nil,
-		"int",
+		endpoints,
 		"a9fb0e79",
 		"test-client",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",
@@ -101,9 +93,10 @@ func TestIAMOauthTokenBasicAuth(t *testing.T) {
 		err    error
 	)
 
-	client, err = NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, err = NewClient(
 		nil,
-		"int",
+		endpoints,
 		"a9fb0e79",
 		"test-client",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",

--- a/iam_group_test.go
+++ b/iam_group_test.go
@@ -6,16 +6,17 @@ import (
 )
 
 func TestIAMGroup(t *testing.T) {
-	client, err := NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, err := NewClient(
 		nil,
-		"int",
+		endpoints,
 		"22b0e55f",
 		"test-client-full",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",
 		"",
 		"silkroad-qa",
 		"HS256",
-		10)
+		300)
 
 	if err != nil {
 		t.Errorf("Error instancing client. Got: %v  Want: nil", err)

--- a/iam_user_test.go
+++ b/iam_user_test.go
@@ -14,31 +14,32 @@ func TestIAMUser(t *testing.T) {
 		err           error
 	)
 
-	client, err = NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, err = NewClient(
 		nil,
-		"int",
+		endpoints,
 		"22b0e55f",
 		"test-client-full",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",
 		"",
 		"silkroad-qa",
 		"HS256",
-		10)
+		300)
 
 	if err != nil {
 		t.Errorf("Error instancing client. Got: %v  Want: nil", err)
 	}
 
-	clientForUser, err = NewClientForEnvironment(
+	clientForUser, err = NewClient(
 		nil,
-		"int",
+		endpoints,
 		"a9fb0e79",
 		"test-client",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",
 		"",
 		"silkroad-qa",
 		"HS256",
-		10)
+		300)
 
 	if err != nil {
 		t.Errorf("Error instancing clientForUser. Got: %v  Want: nil", err)
@@ -87,11 +88,11 @@ func TestIAMUser(t *testing.T) {
 	}
 	if got, want := len(arrUsers), 1; got != want {
 		t.Errorf("Error on search. Got: %v. Expect %v user.", got, want)
+	} else {
+		if arrUsers[0].Username != anUser.Username {
+			t.Errorf("Error user found != user created")
+		}
 	}
-	if arrUsers[0].Username != anUser.Username {
-		t.Errorf("Error user found != user created")
-	}
-
 	anUser2 := IAMUser{}
 	err = client.IAM.UserGet(arrUsers[0].ID, &anUser2)
 	if err != nil {

--- a/resources.go
+++ b/resources.go
@@ -8,8 +8,11 @@ type ResourcesService struct {
 	client *Client
 }
 
-//
-type ACL map[string]string
+// UserACL defines the content of an ACL for a user
+type UserACL struct {
+	Permission string                 `json:"permission"`
+	Properties map[string]interface{} `json:"properties"`
+}
 
 // Resource te
 type Resource struct {

--- a/resources_collection_test.go
+++ b/resources_collection_test.go
@@ -1,8 +1,6 @@
 package corbel
 
 import (
-	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -205,9 +203,6 @@ func TestResourcesGetFromCollection(t *testing.T) {
 	resAcl.ACL = make(map[string]UserACL)
 
 	resAcl.ACL["ALL"] = UserACL{Permission: "READ", Properties: make(map[string]interface{})}
-
-	b, err := json.Marshal(resAcl.ACL)
-	fmt.Println(string(b))
 	err = client.Resources.UpdateResourceACL("test:GoTestResource", resAcl.ID, resAcl.ACL)
 	if err != nil {
 		t.Errorf("Failed to UpdateResourceACL . Got: %v  Want: nil", err)

--- a/resources_collection_test.go
+++ b/resources_collection_test.go
@@ -1,6 +1,8 @@
 package corbel
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -13,16 +15,17 @@ func TestResourcesAddToCollection(t *testing.T) {
 		err    error
 	)
 
-	client, err = NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, err = NewClient(
 		nil,
-		"int",
+		endpoints,
 		"a9fb0e79",
 		"test-client",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",
 		"",
 		"silkroad-qa",
 		"HS256",
-		10)
+		300)
 
 	err = client.IAM.OauthToken()
 	if err != nil {
@@ -69,16 +72,17 @@ func TestResourcesGetFromCollection(t *testing.T) {
 		search *Search
 	)
 
-	client, err = NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, err = NewClient(
 		nil,
-		"int",
+		endpoints,
 		"a9fb0e79",
 		"test-client",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",
 		"",
 		"silkroad-qa",
 		"HS256",
-		10)
+		300)
 
 	err = client.IAM.OauthToken()
 	if err != nil {
@@ -183,9 +187,9 @@ func TestResourcesGetFromCollection(t *testing.T) {
 	}
 
 	type ResourceWithAcl struct {
-		ID   string            `json:"id,omitempty"`
-		Name string            `json:"name,omitempty"`
-		ACL  map[string]string `json:"_acl,omitempty"`
+		ID   string             `json:"id,omitempty"`
+		Name string             `json:"name,omitempty"`
+		ACL  map[string]UserACL `json:"_acl,omitempty"`
 	}
 
 	resAcl := &ResourceWithAcl{
@@ -198,9 +202,12 @@ func TestResourcesGetFromCollection(t *testing.T) {
 	}
 	s := strings.Split(id, "/")
 	resAcl.ID = s[len(s)-1]
-	resAcl.ACL = make(map[string]string)
+	resAcl.ACL = make(map[string]UserACL)
 
-	resAcl.ACL["ALL"] = "READ"
+	resAcl.ACL["ALL"] = UserACL{Permission: "READ", Properties: make(map[string]interface{})}
+
+	b, err := json.Marshal(resAcl.ACL)
+	fmt.Println(string(b))
 	err = client.Resources.UpdateResourceACL("test:GoTestResource", resAcl.ID, resAcl.ACL)
 	if err != nil {
 		t.Errorf("Failed to UpdateResourceACL . Got: %v  Want: nil", err)
@@ -209,11 +216,11 @@ func TestResourcesGetFromCollection(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to UpdateResourceACL (GetResource) . Got: %v  Want: nil", err)
 	}
-	if len(resAcl.ACL) != 1 || resAcl.ACL["ALL"] != "READ" {
+	if len(resAcl.ACL) != 1 || resAcl.ACL["ALL"].Permission != "READ" {
 		t.Errorf("Failed to UpdateResourceACL . Got: %d/%s  Want: 1/READ", len(resAcl.ACL), resAcl.ACL["ALL"])
 	}
 
-	resAcl.ACL["user1"] = "WRITE"
+	resAcl.ACL["user1"] = UserACL{Permission: "WRITE", Properties: make(map[string]interface{})}
 	err = client.Resources.UpdateResourceACL("test:GoTestResource", resAcl.ID, resAcl.ACL)
 	if err != nil {
 		t.Errorf("Failed to UpdateResourceACL . Got: %v  Want: nil", err)
@@ -226,7 +233,7 @@ func TestResourcesGetFromCollection(t *testing.T) {
 		t.Errorf("Failed to UpdateResourceACL . Got: %d  Want: 2", len(resAcl.ACL))
 	}
 
-	resAcl.ACL["user1"] = "READ"
+	resAcl.ACL["user1"] = UserACL{Permission: "READ", Properties: make(map[string]interface{})}
 	err = client.Resources.UpdateResourceACL("test:GoTestResource", resAcl.ID, resAcl.ACL)
 	if err != nil {
 		t.Errorf("Failed to UpdateResourceACL . Got: %v  Want: nil", err)
@@ -235,7 +242,7 @@ func TestResourcesGetFromCollection(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to UpdateResourceACL (GetResource) . Got: %v  Want: nil", err)
 	}
-	if len(resAcl.ACL) != 2 || resAcl.ACL["user1"] != "READ" {
+	if len(resAcl.ACL) != 2 || resAcl.ACL["user1"].Permission != "READ" {
 		t.Errorf("Failed to UpdateResourceACL . Got: %d/%s  Want: 2/READ", len(resAcl.ACL), resAcl.ACL["user1"])
 	}
 
@@ -248,7 +255,7 @@ func TestResourcesGetFromCollection(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to UpdateResourceACL (GetResource) . Got: %v  Want: nil", err)
 	}
-	if len(resAcl.ACL) != 1 || resAcl.ACL["ALL"] != "" {
+	if len(resAcl.ACL) != 1 || resAcl.ACL["ALL"].Permission != "" {
 		t.Errorf("Failed to UpdateResourceACL . Got: %d/%s  Want: 1/", len(resAcl.ACL), resAcl.ACL["ALL"])
 	}
 

--- a/resources_relations_test.go
+++ b/resources_relations_test.go
@@ -9,16 +9,17 @@ func TestResourcesRelations(t *testing.T) {
 		search *Search
 	)
 
-	client, err = NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, err = NewClient(
 		nil,
-		"int",
+		endpoints,
 		"a9fb0e79",
 		"test-client",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",
 		"",
 		"silkroad-qa",
 		"HS256",
-		10)
+		300)
 
 	err = client.IAM.OauthToken()
 	if err != nil {

--- a/searches.go
+++ b/searches.go
@@ -156,16 +156,16 @@ func NewSearch(client *Client, endpoint, baseURL string) *Search {
 
 // Query is the struct that contains the especification of a search
 type apiquery struct {
-	Eq     map[string]string   `json:"$eq,omitempty"`
-	Gt     map[string]int      `json:"$gt,omitempty"`
-	Gte    map[string]int      `json:"$gte,omitempty"`
-	Lt     map[string]int      `json:"$lt,omitempty"`
-	Lte    map[string]int      `json:"$lte,omitempty"`
-	Ne     map[string]string   `json:"$ne,omitempty"`
-	In     map[string][]string `json:"$in,omitempty"`
-	All    map[string][]string `json:"$all,omitempty"`
-	Like   map[string]string   `json:"$like,omitempty"`
-	Exists map[string]bool     `json:"$exists,omitempty"`
+	Eq     map[string]interface{} `json:"$eq,omitempty"`
+	Gt     map[string]int         `json:"$gt,omitempty"`
+	Gte    map[string]int         `json:"$gte,omitempty"`
+	Lt     map[string]int         `json:"$lt,omitempty"`
+	Lte    map[string]int         `json:"$lte,omitempty"`
+	Ne     map[string]string      `json:"$ne,omitempty"`
+	In     map[string][]string    `json:"$in,omitempty"`
+	All    map[string][]string    `json:"$all,omitempty"`
+	Like   map[string]string      `json:"$like,omitempty"`
+	Exists map[string]bool        `json:"$exists,omitempty"`
 }
 
 // QueryString returns the query string to append to the url we are searching for.
@@ -181,7 +181,7 @@ func (q *apiquery) string() string {
 // NewQuery returns a New search struct
 func newQuery() *apiquery {
 	return &apiquery{
-		Eq:     make(map[string]string),
+		Eq:     make(map[string]interface{}),
 		Gt:     make(map[string]int),
 		Gte:    make(map[string]int),
 		Lt:     make(map[string]int),

--- a/searches_test.go
+++ b/searches_test.go
@@ -89,16 +89,17 @@ func TestSortsQueryStrings(t *testing.T) {
 }
 
 func TestSearchQueryString(t *testing.T) {
-	client, _ := NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, _ := NewClient(
 		nil,
-		"int",
+		endpoints,
 		"a9fb0e79",
 		"test-client",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",
 		"",
 		"silkroad-qa",
 		"HS256",
-		10)
+		300)
 
 	search := NewSearch(client, "resources", "/v1.0/resource/test:Collection")
 
@@ -147,9 +148,10 @@ func TestSearchPagingAndAggregation(t *testing.T) {
 		sum   float64
 	)
 
-	client, _ := NewClientForEnvironment(
+	endpoints := map[string]string{"iam": "https://iam-int.bqws.io", "resources": "https://resources-int.bqws.io"}
+	client, _ := NewClient(
 		nil,
-		"int",
+		endpoints,
 		"a9fb0e79",
 		"test-client",
 		"90f6ed907ce7e2426e51aa52a18470195f4eb04725beb41569db3f796a018dbd",


### PR DESCRIPTION
- Now client receives a map of module/endpoint this way any client
  with a custom url can use corbel-go.
- Changed string to interface{} on equals for searches. Thus allowing
  booleans and decimals.
